### PR TITLE
call python3 via env

### DIFF
--- a/snacme.py
+++ b/snacme.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import os
 import sys
 import re


### PR DESCRIPTION
/usr/bin/env should always exist in the same place on every machine but python3 isn't guaranteed to be in /usr/bin